### PR TITLE
Enable CLI and System APIs from Texsydo Web Prototype

### DIFF
--- a/tsd-web---mvp/src/main/kotlin/software/math/tsd/webmvp/cli/Cmd.kt
+++ b/tsd-web---mvp/src/main/kotlin/software/math/tsd/webmvp/cli/Cmd.kt
@@ -1,0 +1,29 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of https://github.com/texsydo/texsydo---mvp
+
+package software.math.tsd.webmvp.cli
+
+import arrow.core.Either
+import arrow.core.None
+import arrow.core.right
+import java.util.*
+
+enum class Cmd {
+    Build,
+}
+
+fun newOp(value: String): Either<None, Cmd> = try {
+    value
+        .split("-")
+        .joinToString(separator = "") { str ->
+            str.replaceFirstChar { ch ->
+                ch.titlecase(Locale.getDefault())
+            }
+        }
+        .let { Cmd.valueOf(it) }
+        .right()
+}
+catch (e: IllegalArgumentException) {
+    Either.Left(None)
+}

--- a/tsd-web---mvp/src/main/kotlin/software/math/tsd/webmvp/system/System.kt
+++ b/tsd-web---mvp/src/main/kotlin/software/math/tsd/webmvp/system/System.kt
@@ -1,0 +1,68 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of https://github.com/texsydo/texsydo---mvp
+
+package software.math.tsd.webmvp.system
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.nio.file.Path
+import java.util.*
+
+fun runCommand(
+    command: String,
+    workingDir: Path? = null,
+): Either<String, String> {
+    val processBuilder = getProcessBuilder(command)
+
+    processBuilder.redirectErrorStream(false)
+
+    if (workingDir != null) {
+        processBuilder.directory(workingDir.toFile())
+    }
+
+    return try {
+        val process = processBuilder.start()
+        val reader = BufferedReader(InputStreamReader(process.inputStream))
+        val stdErrReader =
+            BufferedReader(InputStreamReader(process.errorStream))
+        val output = StringBuilder()
+        val stdErr = StringBuilder()
+        var line: String?
+
+        // Capture standard output
+        while (reader.readLine().also { line = it } != null) {
+            output.append(line).append("\n")
+        }
+
+        // Capture standard error
+        while (stdErrReader.readLine().also { line = it } != null) {
+            stdErr.append(line).append("\n")
+        }
+        val exitCode = process.waitFor()
+        if (exitCode == 0) {
+            output.toString().right()
+        }
+        else {
+            "Command failed with exit code $exitCode, and error message $stdErr"
+                .left()
+        }
+    }
+    catch (e: Exception) {
+        e.printStackTrace()
+        e.message.orEmpty().left()
+    }
+}
+
+fun getProcessBuilder(command: String): ProcessBuilder {
+    val os = System.getProperty("os.name").lowercase(Locale.getDefault())
+    return if (os.contains("win")) ProcessBuilder(
+        *"cmd /c $command"
+            .split("\\s+".toRegex())
+            .toTypedArray()
+    )
+    else ProcessBuilder("sh", "-c", command)
+}

--- a/tsd-web---mvp/src/test/kotlin/software/math/tsd/webmvp/cli/CmdTest.kt
+++ b/tsd-web---mvp/src/test/kotlin/software/math/tsd/webmvp/cli/CmdTest.kt
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of https://github.com/texsydo/texsydo---mvp
+
+package software.math.tsd.webmvp.cli
+
+import arrow.core.Either
+import arrow.core.Either.Left
+import arrow.core.None
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CmdTest {
+    @Test
+    fun lowercaseStringToCmd() {
+        val result = newOp("build")
+
+        assertEquals(Either.Right(Cmd.Build), result)
+    }
+
+    @Test
+    fun capitalizedStringToCmd() {
+        val result = newOp("Build")
+
+        assertEquals(Either.Right(Cmd.Build), result)
+    }
+
+    @Test
+    fun mixedCaseStringToCmd() {
+        val result = newOp("BuIlD")
+
+        assertEquals(Left(None), result)
+    }
+
+    @Test
+    fun unknownStringToLeftNone() {
+        val result = newOp("unknown-command")
+
+        assertEquals(Left(None), result)
+    }
+
+    @Test
+    fun dashedStringWithoutEnumToLeftNone() {
+        val result = newOp("build-op")
+
+        assertEquals(Left(None), result)
+    }
+}


### PR DESCRIPTION
It migrates the structure of the CLI code to allow commands to be implemented, and adds the System API to run commands, such as DoRep for Jekyll. The next features to migrate will require support from both APIs.