### PR TITLE
Add module system with cmd and fs migrations

### DIFF
--- a/tsd-web---mvp/settings.gradle.kts
+++ b/tsd-web---mvp/settings.gradle.kts
@@ -9,4 +9,4 @@ pluginManagement {
 
 rootProject.name = "tsd-web---mvp"
 
-include("mathswe-kt", "web")
+include("mathswe-kt", "system", "web")

--- a/tsd-web---mvp/system/build.gradle.kts
+++ b/tsd-web---mvp/system/build.gradle.kts
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of https://github.com/texsydo/texsydo---mvp
+
+plugins {
+    id("library.build")
+    alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+    implementation(libs.arrow.core)
+    implementation(libs.arrow.fx.coroutines)
+
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.property)
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+}

--- a/tsd-web---mvp/system/src/main/kotlin/system/cmd/Command.kt
+++ b/tsd-web---mvp/system/src/main/kotlin/system/cmd/Command.kt
@@ -1,0 +1,68 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of https://github.com/texsydo/texsydo---mvp
+
+package system.cmd
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.nio.file.Path
+import java.util.*
+
+fun runCommand(
+    command: String,
+    workingDir: Path? = null,
+): Either<String, String> {
+    val processBuilder = getProcessBuilder(command)
+
+    processBuilder.redirectErrorStream(false)
+
+    if (workingDir != null) {
+        processBuilder.directory(workingDir.toFile())
+    }
+
+    return try {
+        val process = processBuilder.start()
+        val reader = BufferedReader(InputStreamReader(process.inputStream))
+        val stdErrReader =
+            BufferedReader(InputStreamReader(process.errorStream))
+        val output = StringBuilder()
+        val stdErr = StringBuilder()
+        var line: String?
+
+        // Capture standard output
+        while (reader.readLine().also { line = it } != null) {
+            output.append(line).append("\n")
+        }
+
+        // Capture standard error
+        while (stdErrReader.readLine().also { line = it } != null) {
+            stdErr.append(line).append("\n")
+        }
+        val exitCode = process.waitFor()
+        if (exitCode == 0) {
+            output.toString().right()
+        }
+        else {
+            "Command failed with exit code $exitCode, and error message $stdErr"
+                .left()
+        }
+    }
+    catch (e: Exception) {
+        e.printStackTrace()
+        e.message.orEmpty().left()
+    }
+}
+
+fun getProcessBuilder(command: String): ProcessBuilder {
+    val os = System.getProperty("os.name").lowercase(Locale.getDefault())
+    return if (os.contains("win")) ProcessBuilder(
+        *"cmd /c $command"
+            .split("\\s+".toRegex())
+            .toTypedArray()
+    )
+    else ProcessBuilder("sh", "-c", command)
+}

--- a/tsd-web---mvp/system/src/main/kotlin/system/file/FileSystem.kt
+++ b/tsd-web---mvp/system/src/main/kotlin/system/file/FileSystem.kt
@@ -1,0 +1,90 @@
+// Copyright (c) 2023-2025 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// This file is part of https://github.com/texsydo/texsydo---mvp
+
+package system.file
+
+import arrow.core.Either
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import arrow.core.None
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.stream.Stream
+import kotlin.io.path.name
+
+fun deleteDirectory(directory: Path): Either<String, None> {
+    val deleteFilesFromWalk: (Stream<Path>) -> Right<None> = { stream ->
+        stream
+            .sorted(Comparator.reverseOrder())
+            .forEach(Files::delete)
+        Right(None)
+    }
+
+    if (!Files.isDirectory(directory)) {
+        return Left("Provided path is not a directory")
+    }
+    return try {
+        Files.walk(directory).use { deleteFilesFromWalk(it) }
+    }
+    catch (e: IOException) {
+        e.printStackTrace()
+        Left("Fail to delete directory $directory: ${e.message}")
+    }
+}
+
+fun copyDirectory(
+    sourceDir: Path,
+    targetDir: Path,
+    predicate: (Path) -> Boolean = { true },
+): Either<String, Unit> {
+    val renameIfHiddenFile: (Path) -> Path = {
+        if (it.name.startsWith("-."))
+            it.parent.resolve(it.name.removePrefix("-"))
+        else it
+    }
+
+    val copyFileFromWalk: (Stream<Path>) -> Right<Unit> = { stream ->
+        stream
+            .filter(predicate)
+            .forEach { sourcePath ->
+                val relativePath = sourceDir.relativize(sourcePath)
+                val targetPath = targetDir.resolve(relativePath)
+
+                if (Files.isDirectory(sourcePath)) {
+                    Files.createDirectories(targetPath)
+                }
+                else {
+                    val targetFilePath = renameIfHiddenFile(targetPath)
+
+                    Files.copy(
+                        sourcePath,
+                        targetFilePath,
+                        StandardCopyOption.REPLACE_EXISTING
+                    )
+                }
+            }
+        Right(Unit)
+    }
+
+    return try {
+        Files.walk(sourceDir).use { copyFileFromWalk(it) }
+    }
+    catch (e: IOException) {
+        e.printStackTrace()
+        Left("Fail to copy directory $sourceDir into $targetDir: ${e.message}")
+    }
+}
+
+fun deleteEmptyDirectories(rootDir: Path) {
+    Files.walk(rootDir)
+        .sorted(Comparator.reverseOrder())
+        .filter { Files.isDirectory(it) }
+        .filter { Files.list(it).use { stream -> stream.count() == 0L } }
+        .forEach { Files.deleteIfExists(it) }
+}
+
+fun getFileExtension(path: Path): String =
+    path.toString().substringAfterLast('.', missingDelimiterValue = "")


### PR DESCRIPTION
It adds the Gradle module `system` to the `tsd-web---mvp` project, along with the migrations that enabled the Web Prototype to run system commands and operate on the file system via a few utility methods.